### PR TITLE
Add auto discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ var Fibaro = require('fibaro-api');
 var fibaro = new Fibaro('xxx.xxx.xxx.xxx', 'username', 'password');
 ```
 
+Alternatively, to attempt auto discovery :
+```javascript
+Fibaro.discover(function(info) {
+    var fibaro = new Fibaro(info.ip, 'username', 'password');
+});
+```
+
 Make your calls :
 
 ```javascript

--- a/examples/discovery.js
+++ b/examples/discovery.js
@@ -1,0 +1,12 @@
+var Fibaro = require('../lib/fibaro');
+
+Fibaro.discover(function(info) {
+
+    console.log('Discovered device', info.serial, 'at', info.ip);
+
+    var fibaro = new Fibaro(info.ip, 'username', 'password');
+
+    fibaro.api.devices.list(function(err, data) {
+    	console.log(data);
+    });
+});

--- a/lib/fibaro.js
+++ b/lib/fibaro.js
@@ -123,6 +123,36 @@ var FibaroClient = module.exports = function(host, user, pass) {
     };
 }
 
+FibaroClient.discover = function (callback, timeout) {
+
+    var re = /^ACK (HC2-[0-9]+) ([0-9a-f:]+)$/;
+
+    var server = require('dgram').createSocket("udp4");
+
+    server.on('message', function (packet, rinfo) {
+
+        var matches = re.exec(packet.toString());
+
+        if (matches) {
+            callback({
+                ip: rinfo.address,
+                serial: matches[1],
+                mac: matches[2]
+            });
+        }
+    });
+
+    server.bind(44444, function () {
+        var message = new Buffer("FIBARO");
+        server.setBroadcast(true);
+        server.send(message, 0, message.length, 44444, "255.255.255.255");
+    });
+
+    setTimeout(function () {
+        server.close();
+    }, timeout || 5000);
+};
+
 /* Custom error objects */
 var AbstractError = function (msg, constr) {
   Error.captureStackTrace(this, constr || this)


### PR DESCRIPTION
It is possible to scan the local network for Home Centers by sending a special UDP broadcast packet. This removes the need to enter the IP address of the device manually.
